### PR TITLE
Lightened red color in instructions

### DIFF
--- a/visual/main.css
+++ b/visual/main.css
@@ -137,5 +137,5 @@ footer {
 }
 
 .red {
-    color: #e40;
+    color: #ff9166;
 }


### PR DESCRIPTION
Just changed Lightness in the color's HSL representation from 47% to 70%.

Yes, now it is no longer the exact same color as the actual red square. But it's easier to read the red text against the black background of the instructions bubble, and it's still red enough to look like the square.

Some possible alternatives to this:
give .red a white background so you can use the original red color and and still read it
keep this change, and also change the name of this class to .instructions-red so we don't confuse it with the red color of the end position square
