### PR TITLE
Fixing documentation syntax.

### DIFF
--- a/src/finders/JumpPointFinder.js
+++ b/src/finders/JumpPointFinder.js
@@ -110,7 +110,7 @@ JumpPointFinder.prototype._identifySuccessors = function(node) {
 };
 
 /**
- Search recursively in the direction (parent -> child), stopping only when a
+ * Search recursively in the direction (parent -> child), stopping only when a
  * jump point is found.
  * @protected
  * @return {Array.<[number, number]>} The x, y coordinate of the jump point


### PR DESCRIPTION
Just a (very) very minor "typo" I got while reading the source =]
