### PR TITLE
Additional visualisation for Jump Point Search

### DIFF
--- a/lib/pathfinding-browser.js
+++ b/lib/pathfinding-browser.js
@@ -1393,6 +1393,7 @@ var Heuristic  = require('../core/Heuristic');
 function JumpPointFinder(opt) {
     opt = opt || {};
     this.heuristic = opt.heuristic || Heuristic.manhattan;
+    this.trackJumpRecursion = opt.trackJumpRecursion || false;
 }
 
 /**
@@ -1489,7 +1490,7 @@ JumpPointFinder.prototype._identifySuccessors = function(node) {
 };
 
 /**
- Search recursively in the direction (parent -> child), stopping only when a
+ * Search recursively in the direction (parent -> child), stopping only when a
  * jump point is found.
  * @protected
  * @return {Array.<[number, number]>} The x, y coordinate of the jump point
@@ -1502,7 +1503,12 @@ JumpPointFinder.prototype._jump = function(x, y, px, py) {
     if (!grid.isWalkableAt(x, y)) {
         return null;
     }
-    else if (grid.getNodeAt(x, y) === this.endNode) {
+    
+    if(this.trackJumpRecursion === true) {
+        grid.getNodeAt(x, y).jumptest = true;
+    }
+    
+    if (grid.getNodeAt(x, y) === this.endNode) {
         return [x, y];
     }
 

--- a/src/finders/JumpPointFinder.js
+++ b/src/finders/JumpPointFinder.js
@@ -14,6 +14,7 @@ var Heuristic  = require('../core/Heuristic');
 function JumpPointFinder(opt) {
     opt = opt || {};
     this.heuristic = opt.heuristic || Heuristic.manhattan;
+    this.trackJumpRecursion = opt.trackJumpRecursion || false;
 }
 
 /**
@@ -123,7 +124,12 @@ JumpPointFinder.prototype._jump = function(x, y, px, py) {
     if (!grid.isWalkableAt(x, y)) {
         return null;
     }
-    else if (grid.getNodeAt(x, y) === this.endNode) {
+    
+    if(this.trackJumpRecursion === true) {
+        grid.getNodeAt(x, y).jumptest = true;
+    }
+    
+    if (grid.getNodeAt(x, y) === this.endNode) {
         return [x, y];
     }
 

--- a/visual/index.html
+++ b/visual/index.html
@@ -145,6 +145,13 @@
             <input type="radio" name="jump_point_heuristic" value="chebyshev"/>
             <label class="option_label">Chebyshev</label> <br>
           </div>
+          <header class="option_header">
+            <h3>Options</h3>
+          </header>
+          <div class="optional sub_options">
+            <input type="checkbox" class="track_jump_recursion" checked>
+            <label class="option_label">Visualize recursion</label> <br>
+            
         </div>
       </div><!-- .accordion -->
     </div><!-- #algorithm_panel -->

--- a/visual/js/controller.js
+++ b/visual/js/controller.js
@@ -320,6 +320,15 @@ $.extend(Controller, {
                     value: v
                 });
             },
+            set jumptest(v) {
+                Controller.operations.push({
+                    x: this.x,
+                    y: this.y,
+                    attr: 'jumptest',
+                    jumptested: true,
+                    value: v
+                });
+            },
         };
 
         this.operations = [];

--- a/visual/js/panel.js
+++ b/visual/js/panel.js
@@ -25,7 +25,7 @@ var Panel = {
      * TODO: clean up this messy code.
      */
     getFinder: function() {
-        var finder, selected_header, heuristic, allowDiagonal, biDirectional, dontCrossCorners, weight;
+        var finder, selected_header, heuristic, allowDiagonal, biDirectional, dontCrossCorners, weight, trackJumpRecursion;
         
         selected_header = $(
             '#algorithm_panel ' +
@@ -128,8 +128,12 @@ var Panel = {
             break;
 
         case 'jump_point_header':
+            trackJumpRecursion = typeof $('#jump_point_section ' +
+                                     '.track_jump_recursion:checked').val() !== 'undefined';
             heuristic = $('input[name=jump_point_heuristic]:checked').val();
+            
             finder = new PF.JumpPointFinder({
+              trackJumpRecursion: trackJumpRecursion,
               heuristic: PF.Heuristic[heuristic]
             });
             break;

--- a/visual/js/view.js
+++ b/visual/js/view.js
@@ -33,6 +33,10 @@ var View = {
             fill: '#ff8888',
             'stroke-opacity': 0.2,
         },
+        jumptest: {
+            fill: '#e5e5e5',
+            'stroke-opacity': 0.2,
+        },
     },
     nodeColorizeEffect: {
         duration: 50,
@@ -46,7 +50,7 @@ var View = {
         stroke: 'yellow',
         'stroke-width': 3,
     },
-    supportedOperations: ['opened', 'closed'],
+    supportedOperations: ['opened', 'closed', 'jumptest'],
     init: function(opts) {
         this.numCols      = opts.numCols;
         this.numRows      = opts.numRows;
@@ -155,6 +159,10 @@ var View = {
             break;
         case 'closed':
             this.colorizeNode(this.rects[gridY][gridX], nodeStyle.closed.fill);
+            this.setCoordDirty(gridX, gridY, true);
+            break;
+        case 'jumptest':
+            this.colorizeNode(this.rects[gridY][gridX], nodeStyle.jumptest.fill);
             this.setCoordDirty(gridX, gridY, true);
             break;
         case 'parent':


### PR DESCRIPTION
Ability to track nodes tested by Jump Point Search's recursion. The visual interface has been updated with a checkbox to enable / disable this representation.

I feel this more closely represents the inner workings of Jump Point Search; in particular highlighting the best and worse case scenarios. A sample has been published here: http://gerjo.github.io/PathFinding.js/visual/
