### PR TITLE
Exception when running the benchmark on windows

### DIFF
--- a/benchmark/parse_map.js
+++ b/benchmark/parse_map.js
@@ -30,10 +30,11 @@
  */
 
 var fs = require('fs');
+var endOfLine = require('os').EOL;
 
 function parse(filename) {
   var content = fs.readFileSync(filename).toString();
-  var lines = content.split('\n');
+  var lines = content.split(endOfLine);
   return {
     height : parseInt(lines[1].split(' ')[1]),
     width  : parseInt(lines[2].split(' ')[1]),


### PR DESCRIPTION
Got the following exception when running the benchmark on windows -

Error: Matrix size does not fit
    at Grid._buildNodes (D:\src\git\other\PathFinding.js\src\core\Grid.js:56:15)
    at new Grid (D:\src\git\other\PathFinding.js\src\core\Grid.js:26:23)
    at map2grid (D:\src\git\other\PathFinding.js\benchmark\benchmark.js:54:10)
    at D:\src\git\other\PathFinding.js\benchmark\benchmark.js:60:14
    at Array.forEach (native)
    at Object.<anonymous> (D:\src\git\other\PathFinding.js\benchmark\benchmark.js:58:11)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)

The problem was that the line ending was assumed to be unix. 
