### PR TITLE
add `allowCrossDiagnal` option

### DIFF
--- a/src/core/Grid.js
+++ b/src/core/Grid.js
@@ -132,7 +132,7 @@ Grid.prototype.setWalkableAt = function(x, y, walkable) {
  * @param {boolean} allowDiagonal
  * @param {boolean} dontCrossCorners
  */
-Grid.prototype.getNeighbors = function(node, allowDiagonal, dontCrossCorners) {
+Grid.prototype.getNeighbors = function(node, allowDiagonal, dontCrossCorners, allowCrossDiagnal) {
     var x = node.x,
         y = node.y,
         neighbors = [],
@@ -173,10 +173,10 @@ Grid.prototype.getNeighbors = function(node, allowDiagonal, dontCrossCorners) {
         d2 = s1 && s2;
         d3 = s2 && s3;
     } else {
-        d0 = s3 || s0;
-        d1 = s0 || s1;
-        d2 = s1 || s2;
-        d3 = s2 || s3;
+        d0 = s3 || s0 || allowCrossDiagnal;
+        d1 = s0 || s1 || allowCrossDiagnal;
+        d2 = s1 || s2 || allowCrossDiagnal;
+        d3 = s2 || s3 || allowCrossDiagnal;
     }
 
     // ↖

--- a/src/finders/AStarFinder.js
+++ b/src/finders/AStarFinder.js
@@ -18,6 +18,7 @@ function AStarFinder(opt) {
     opt = opt || {};
     this.allowDiagonal = opt.allowDiagonal;
     this.dontCrossCorners = opt.dontCrossCorners;
+    this.allowCrossDiagnal = opt.allowCrossDiagnal;
     this.heuristic = opt.heuristic || Heuristic.manhattan;
     this.weight = opt.weight || 1;
 }
@@ -36,6 +37,7 @@ AStarFinder.prototype.findPath = function(startX, startY, endX, endY, grid) {
         heuristic = this.heuristic,
         allowDiagonal = this.allowDiagonal,
         dontCrossCorners = this.dontCrossCorners,
+        allowCrossDiagnal = this.allowCrossDiagnal,
         weight = this.weight,
         abs = Math.abs, SQRT2 = Math.SQRT2,
         node, neighbors, neighbor, i, l, x, y, ng;
@@ -60,7 +62,7 @@ AStarFinder.prototype.findPath = function(startX, startY, endX, endY, grid) {
         }
 
         // get neigbours of the current node
-        neighbors = grid.getNeighbors(node, allowDiagonal, dontCrossCorners);
+        neighbors = grid.getNeighbors(node, allowDiagonal, dontCrossCorners, allowCrossDiagnal);
         for (i = 0, l = neighbors.length; i < l; ++i) {
             neighbor = neighbors[i];
 


### PR DESCRIPTION
This option allows movements like this:

![Imgur](http://imgur.com/u6KmpLe.png)

Note this is the desired behavior when it's hostile creatures instead of walls. When this option is used, usually wall corners are always connected.

This PR only changed the AStar finder - if you think this is a good idea, I can modify other finders and their respective comments/documentations as well.
