### PR TITLE
updates clean target at makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,6 @@ test:
 			--bail
 
 clean:
-	rm -f lib/pathfinding-browser.js
+	rm -rf lib/
 
 .PHONY: test clean


### PR DESCRIPTION
`make clean` is not actually deleting what was generated by the building process. The non-minified version used to remain there. With this new version we get what is expected: what it was before running the build
