### PR TITLE
Updates package.json to have postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
   , "main"            : "./index.js"
   , "dependencies"    : {
       "heap"          : "0.2.2"
+    , "uglify-js"       : "2.3.6"
+    , "browserify"      : "2.25.0"
   }
   , "devDependencies" : {
-      "uglify-js"       : "2.3.6"
-    , "colors"          : "0.6.x"
-    , "browserify"      : "2.25.0"
+      "colors"          : "0.6.x"
     , "mocha"           : "1.0.x"
     , "should"          : "0.6.x"
   }


### PR DESCRIPTION
As having release stuff in the souce code sucks and we want to be able to have access to those files when running `npm install`, e.g, by having a `postinstall` script setten up we can achieve that. 

---

Just like jquery (https://github.com/jquery/jquery/pull/1620), we could drop bower support and go along with npm itself 
