### PR TITLE
moved opts to constructor for new browserify version

### DIFF
--- a/utils/build.js
+++ b/utils/build.js
@@ -7,7 +7,7 @@ var browserify = require('browserify');
 
 function bundle(file, callback) {
   var opts = { standalone: 'PF' };
-  browserify(file).bundle(opts, callback);
+  browserify(file, opts).bundle(callback);
 }
 
 function addBanner(source) {


### PR DESCRIPTION
The new browserify version (at least browserify-5.12.1) changed the behavior a bit. I got the following error when I tried to build with original sources.
"Error: bundle() no longer accepts option arguments.
Move all option arguments to the browserify() constructor.
    at Browserify.bundle (~/PathFinding.js/node_modules/browserify/index.js:604:15)
    at ..."
So I fixed the line to get it working with the lastest version.
