### PR TITLE
Updating Grid() constructor to accept just a matrix argument

### DIFF
--- a/docs/contributor-guide/authors.md
+++ b/docs/contributor-guide/authors.md
@@ -17,5 +17,6 @@ Rory O'Kane <https://github.com/roryokane><br>
 Stuart Lee <https://github.com/beeglebug><br>
 surrim <https://github.com/surrim><br>
 Tapio Vierros <https://github.com/tapio><br>
+Thomas Hunter II <https://github.com/tlhunter><br>
 Willem Mulder <https://github.com/willemmulder><br>
 Xueqiao Xu <https://github.com/qiao>

--- a/docs/user-guide/introduction.md
+++ b/docs/user-guide/introduction.md
@@ -10,7 +10,7 @@ var matrix = [
     [1, 0, 0, 0, 1],
     [0, 0, 1, 0, 0],
 ];
-var grid = new PF.Grid(5, 3, matrix);
+var grid = new PF.Grid(matrix);
 var finder = new PF.AStarFinder();
 //Find path from (1, 2) to (4, 2)
 var path = finder.findPath(1, 2, 4, 2, grid);

--- a/docs/user-guide/obstacles.md
+++ b/docs/user-guide/obstacles.md
@@ -9,7 +9,7 @@ var walkabilityMatrix = [[0, 0, 0, 0, 0],
                          [0, 0, 0, 0, 0],
                          [1, 1, 1, 1, 0],
                          [0, 0, 0, 0, 0]];
-var grid = new PF.Grid(5, 7, matrix);
+var grid = new PF.Grid(matrix);
 ```
 
 The _walkabilityMatrix_ defines which cells are walkable and which have

--- a/src/core/Grid.js
+++ b/src/core/Grid.js
@@ -4,12 +4,22 @@ var DiagonalMovement = require('./DiagonalMovement');
 /**
  * The Grid class, which serves as the encapsulation of the layout of the nodes.
  * @constructor
- * @param {number} width Number of columns of the grid.
+ * @param {number|Array.<Array.<(number|boolean)>>} width_or_matrix Number of columns of the grid, or matrix
  * @param {number} height Number of rows of the grid.
  * @param {Array.<Array.<(number|boolean)>>} [matrix] - A 0-1 matrix
  *     representing the walkable status of the nodes(0 or false for walkable).
  *     If the matrix is not supplied, all the nodes will be walkable.  */
-function Grid(width, height, matrix) {
+function Grid(width_or_matrix, height, matrix) {
+    var width;
+
+    if (typeof width_or_matrix !== 'object') {
+        width = width_or_matrix;
+    } else {
+        height = width_or_matrix.length;
+        width = width_or_matrix[0].length;
+        matrix = width_or_matrix;
+    }
+
     /**
      * The number of columns of the grid.
      * @type number

--- a/test/Grid.js
+++ b/test/Grid.js
@@ -107,7 +107,7 @@ describe('Grid', function() {
                 [width, 0, false],
                 [width, height, false],
             ];
-            
+
             asserts.forEach(function(v, i, a) {
                 grid.isInside(v[0], v[1]).should.equal(v[2]);
             });
@@ -121,6 +121,35 @@ describe('Grid', function() {
             grid.getNeighbors(grid.nodes[0][2], DiagonalMovement.IfAtMostOneObstacle).sort(cmp).should.eql([
                 grid.nodes[0][1], grid.nodes[1][2], grid.nodes[1][3]
             ].sort(cmp))
+        });
+    });
+
+    describe('generate with matrix and no width or height', function() {
+        var matrix, grid;
+
+        beforeEach(function() {
+            matrix = [
+                [1, 0, 0, 1],
+                [0, 1, 0, 0],
+                [0, 1, 0, 0],
+                [0, 0, 0, 0],
+                [1, 0, 0, 1],
+            ];
+
+            grid = new Grid(matrix);
+        });
+
+        it('should have correct size', function() {
+            var height = matrix.length;
+            var width = matrix[0].length;
+
+            grid.width.should.equal(width);
+            grid.height.should.equal(height);
+
+            grid.nodes.length.should.equal(height);
+            for (var i = 0; i < height; ++i) {
+                grid.nodes[i].length.should.equal(width);
+            }
         });
     });
 });


### PR DESCRIPTION
Currently if someone uses PathFinding.js and instantiates a Grid using a matrix, they always have to do the following:

```javascript
var grid = new PF.Grid(MATRIX[0].length, MATRIX.length, MATRIX);
```

However PathFinding.js can of course determine the width and height using the provided matrix (in fact, that's how the unit tests already work). Removing the need for them would make for a friendlier API.

This change allows the existing two methods of instantiating a Grid, as well as a third more convenient method:

```javascript
var grid = new PF.Grid(WIDTH, HEIGHT); // existing signature, all walkable matrix
var grid = new PF.Grid(WIDTH, HEIGHT, MATRIX); // existing signature, matrix
var grid = new PF.Grid(MATRIX); // new signature, just matrix
```