### PR TITLE
New diagonal movement option: only to squeeze between diagonal obstacles.

### DIFF
--- a/src/core/DiagonalMovement.js
+++ b/src/core/DiagonalMovement.js
@@ -2,7 +2,8 @@ var DiagonalMovement = {
     Always: 1,
     Never: 2,
     IfAtMostOneObstacle: 3,
-    OnlyWhenNoObstacles: 4
+    OnlyWhenNoObstacles: 4,
+    OnlyWhenObstacles: 5,
 };
 
 module.exports = DiagonalMovement;

--- a/src/core/Grid.js
+++ b/src/core/Grid.js
@@ -192,6 +192,11 @@ Grid.prototype.getNeighbors = function(node, diagonalMovement) {
         d1 = true;
         d2 = true;
         d3 = true;
+    } else if (diagonalMovement === DiagonalMovement.OnlyWhenObstacles) {
+        d0 = !(s3 || s0);
+        d1 = !(s0 || s1);
+        d2 = !(s1 || s2);
+        d3 = !(s2 || s3);
     } else {
         throw new Error('Incorrect value of diagonalMovement');
     }


### PR DESCRIPTION
I've made this modification in my local copy to mimic movement in Tibia:
Using this option, the pathfinder only routes diagonally when it has to "squeeze between" two diagonal objects (two trees/bushes), otherwise it sticks to N/E/S/W paths.