### PR TITLE
if f-values are equal (<0.0001) compare h-values

### DIFF
--- a/src/finders/AStarFinder.js
+++ b/src/finders/AStarFinder.js
@@ -52,7 +52,9 @@ function AStarFinder(opt) {
  */
 AStarFinder.prototype.findPath = function(startX, startY, endX, endY, grid) {
     var openList = new Heap(function(nodeA, nodeB) {
-            return nodeA.f - nodeB.f;
+            var MAX_DIFF = 0.000001;
+            var diff = nodeA.f - nodeB.f;
+            return abs(diff) < MAX_DIFF ? nodeA.h - nodeB.h : diff;
         }),
         startNode = grid.getNodeAt(startX, startY),
         endNode = grid.getNodeAt(endX, endY),

--- a/src/finders/BiAStarFinder.js
+++ b/src/finders/BiAStarFinder.js
@@ -52,7 +52,9 @@ function BiAStarFinder(opt) {
  */
 BiAStarFinder.prototype.findPath = function(startX, startY, endX, endY, grid) {
     var cmp = function(nodeA, nodeB) {
-            return nodeA.f - nodeB.f;
+            var MAX_DIFF = 0.000001;
+            var diff = nodeA.f - nodeB.f;
+            return abs(diff) < MAX_DIFF ? nodeA.h - nodeB.h : diff;
         },
         startOpenList = new Heap(cmp),
         endOpenList = new Heap(cmp),

--- a/src/finders/JumpPointFinderBase.js
+++ b/src/finders/JumpPointFinderBase.js
@@ -25,10 +25,13 @@ function JumpPointFinderBase(opt) {
  */
 JumpPointFinderBase.prototype.findPath = function(startX, startY, endX, endY, grid) {
     var openList = this.openList = new Heap(function(nodeA, nodeB) {
-            return nodeA.f - nodeB.f;
+            var MAX_DIFF = 0.000001;
+            var diff = nodeA.f - nodeB.f;
+            return abs(diff) < MAX_DIFF ? nodeA.h - nodeB.h : diff;
         }),
         startNode = this.startNode = grid.getNodeAt(startX, startY),
-        endNode = this.endNode = grid.getNodeAt(endX, endY), node;
+        endNode = this.endNode = grid.getNodeAt(endX, endY), node,
+        abs = Math.abs;
 
     this.grid = grid;
 


### PR DESCRIPTION
Comparing h-values (heuristic to target) when f-values (overall cost) are equal. So nodes closer to the destination with the same f-value will be expanded first. This reduces the size of the open list and speedups pathfinding in A*, BiDi-A* and JPS. Looks very cute with A* and octile heuristics. MAX_DIFF (=0.000001) is used to compare the floats.
