### PR TITLE
Remove unused row variable in Grid

### DIFF
--- a/src/core/Grid.js
+++ b/src/core/Grid.js
@@ -48,8 +48,7 @@ function Grid(width_or_matrix, height, matrix) {
  */
 Grid.prototype._buildNodes = function(width, height, matrix) {
     var i, j,
-        nodes = new Array(height),
-        row;
+        nodes = new Array(height);
 
     for (i = 0; i < height; ++i) {
         nodes[i] = new Array(width);
@@ -229,8 +228,7 @@ Grid.prototype.clone = function() {
         thisNodes = this.nodes,
 
         newGrid = new Grid(width, height),
-        newNodes = new Array(height),
-        row;
+        newNodes = new Array(height);
 
     for (i = 0; i < height; ++i) {
         newNodes[i] = new Array(width);


### PR DESCRIPTION
Removed the unused 'row' variable from Grid.prototype._buildNodes and Grid.prototype.clone. In both functions, the variable was initialized, but never used or assigned a value. Removing the unused variable makes the code more readable. No other files were changed.