### PR TITLE
feat: Add unitSize to AStarFinder

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ Basic Usage
 To build a grid-map of width 5 and height 3:
 
 ```javascript
-var grid = new PF.Grid(5, 3); 
+var grid = new PF.Grid(5, 3);
 ```
 
 By default, all the nodes in the grid will be able to be walked through.
 To set whether a node at a given coordinate is walkable or not, use the `setWalkableAt` method.
 
-For example, to set the node at (0, 1) to be un-walkable, where 0 is the x coordinate (from left to right), and 
+For example, to set the node at (0, 1) to be un-walkable, where 0 is the x coordinate (from left to right), and
 1 is the y coordinate (from up to down):
 
 ```javascript
@@ -182,6 +182,22 @@ var finder = new PF.BestFirstFinder({
 });
 ```
 
+For `AStarFinder`, you can specify an `unitSize` if your unit/character/object that you're trying to move is larger than a cell :
+
+```javascript
+var finder = new PF.BestFirstFinder({
+    unitSize : 2,
+});
+```
+
+When using `unitSize`, you can have access to the clearance grid :
+
+```javascript
+finder.findPath(grid);
+// A grid of nodes with clearance values
+finder.getClearanceGrid(grid);
+```
+
 To smoothen the path, you may use `PF.Util.smoothenPath`. This routine will return
 a new path with the original one unmodified.
 
@@ -219,9 +235,9 @@ Layout:
 	|-- benchmark    # benchmarks
     `-- visual       # visualization
 
-Make sure you have `node.js` installed, then use `npm` to install the dependencies: 
+Make sure you have `node.js` installed, then use `npm` to install the dependencies:
 
-    npm install -d 
+    npm install -d
 
 The build system uses gulp, so make sure you have it installed:
 

--- a/docs/contributor-guide/authors.md
+++ b/docs/contributor-guide/authors.md
@@ -7,6 +7,7 @@ Chris Khoo <https://github.com/chriskck><br>
 Gerjo <https://github.com/Gerjo><br>
 Juan Pablo Canepa <https://github.com/jpcanepa><br>
 Mat Gadd <https://github.com/Drarok><br>
+Matthieu Lemoine <https://github.com/MatthieuLemoine><br>
 Murilo Pereira <https://github.com/mpereira><br>
 Nathan Witmer <https://github.com/zerowidth><br>
 rafaelcastrocouto <https://github.com/rafaelcastrocouto><br>

--- a/src/core/Grid.js
+++ b/src/core/Grid.js
@@ -233,7 +233,7 @@ Grid.prototype.clone = function() {
     for (i = 0; i < height; ++i) {
         newNodes[i] = new Array(width);
         for (j = 0; j < width; ++j) {
-            newNodes[i][j] = new Node(j, i, thisNodes[i][j].walkable);
+            newNodes[i][j] = new Node(j, i, thisNodes[i][j].walkable, thisNodes[i][j].clearance);
         }
     }
 

--- a/src/core/Node.js
+++ b/src/core/Node.js
@@ -1,13 +1,14 @@
 /**
- * A node in grid. 
- * This class holds some basic information about a node and custom 
+ * A node in grid.
+ * This class holds some basic information about a node and custom
  * attributes may be added, depending on the algorithms' needs.
  * @constructor
  * @param {number} x - The x coordinate of the node on the grid.
  * @param {number} y - The y coordinate of the node on the grid.
  * @param {boolean} [walkable] - Whether this node is walkable.
+ * @param {number} [clearance] - Clearance value of the node.
  */
-function Node(x, y, walkable) {
+function Node(x, y, walkable, clearance) {
     /**
      * The x coordinate of the node on the grid.
      * @type number
@@ -23,6 +24,20 @@ function Node(x, y, walkable) {
      * @type boolean
      */
     this.walkable = (walkable === undefined ? true : walkable);
+    /**
+     * Clearance value of the node.
+     * @type boolean
+     */
+    this.clearance = (clearance === undefined ? 0 : clearance);
+}
+
+/**
+ * Get clearance node value.
+ */
+Node.prototype.getClearance = function() {
+    if (!this.walkable) {
+        return 0;
+    }
 }
 
 module.exports = Node;

--- a/src/core/Node.js
+++ b/src/core/Node.js
@@ -31,13 +31,4 @@ function Node(x, y, walkable, clearance) {
     this.clearance = (clearance === undefined ? 0 : clearance);
 }
 
-/**
- * Get clearance node value.
- */
-Node.prototype.getClearance = function() {
-    if (!this.walkable) {
-        return 0;
-    }
-}
-
 module.exports = Node;

--- a/src/finders/AStarFinder.js
+++ b/src/finders/AStarFinder.js
@@ -9,13 +9,14 @@ var DiagonalMovement = require('../core/DiagonalMovement');
  * @param {Object} opt
  * @param {boolean} opt.allowDiagonal Whether diagonal movement is allowed.
  *     Deprecated, use diagonalMovement instead.
- * @param {boolean} opt.dontCrossCorners Disallow diagonal movement touching 
+ * @param {boolean} opt.dontCrossCorners Disallow diagonal movement touching
  *     block corners. Deprecated, use diagonalMovement instead.
  * @param {DiagonalMovement} opt.diagonalMovement Allowed diagonal movement.
  * @param {function} opt.heuristic Heuristic function to estimate the distance
  *     (defaults to manhattan).
  * @param {number} opt.weight Weight to apply to the heuristic to allow for
  *     suboptimal paths, in order to speed up the search.
+ * @param {number} opt.unitSize Size of the moving unit
  */
 function AStarFinder(opt) {
     opt = opt || {};
@@ -24,6 +25,8 @@ function AStarFinder(opt) {
     this.heuristic = opt.heuristic || Heuristic.manhattan;
     this.weight = opt.weight || 1;
     this.diagonalMovement = opt.diagonalMovement;
+    this.unitSize = opt.unitSize || 1;
+    this.withClearance = this.unitSize !== 1;
 
     if (!this.diagonalMovement) {
         if (!this.allowDiagonal) {
@@ -63,6 +66,10 @@ AStarFinder.prototype.findPath = function(startX, startY, endX, endY, grid) {
         abs = Math.abs, SQRT2 = Math.SQRT2,
         node, neighbors, neighbor, i, l, x, y, ng;
 
+
+    if (this.withClearance) {
+        this.calculateClearance(grid);
+    }
     // set the `g` and `f` value of the start node to be 0
     startNode.g = 0;
     startNode.f = 0;
@@ -107,7 +114,9 @@ AStarFinder.prototype.findPath = function(startX, startY, endX, endY, grid) {
                 neighbor.parent = node;
 
                 if (!neighbor.opened) {
-                    openList.push(neighbor);
+                    if (!this.withClearance || neighbor.clearance >= this.unitSize) {
+                        openList.push(neighbor);
+                    }
                     neighbor.opened = true;
                 } else {
                     // the neighbor can be reached with smaller cost.
@@ -122,5 +131,42 @@ AStarFinder.prototype.findPath = function(startX, startY, endX, endY, grid) {
     // fail to find the path
     return [];
 };
+
+/**
+ * Generate the clearance grid.
+ */
+AStarFinder.prototype.calculateClearance = function(grid) {
+    // Recursive from the bottom right
+    for (var x = grid.width-1; x>=0; x--) {
+        for(var y = grid.height - 1; y>=0; y--) {
+            var n = grid.getNodeAt(x, y);
+            this.annotateNode(n, grid);
+        }
+    }
+};
+
+/**
+ * Annotate a node with clearance value.
+ */
+AStarFinder.prototype.annotateNode = function(n, grid) {
+    if (!n.walkable) {
+        return 0;
+    }
+    var x = n.x;
+    var y = n.y;
+    // On border
+    if (x + 1 >= grid.width || y + 1 >= grid.height) {
+        n.clearance = 1;
+    } else {
+        // Adjacent neighbours
+        var adj1 = grid.getNodeAt(x+1, y+1);
+        var adj2 = grid.getNodeAt(x+1,y);
+        var adj3 = grid.getNodeAt(x,y+1);
+        if (adj1 && adj2 && adj3) {
+            n.clearance = Math.min(adj1.clearance, adj2.clearance, adj3.clearance) + 1;
+        }
+    }
+};
+
 
 module.exports = AStarFinder;

--- a/src/finders/AStarFinder.js
+++ b/src/finders/AStarFinder.js
@@ -172,7 +172,7 @@ AStarFinder.prototype.annotateNode = function(n, grid) {
  * Get a grid with clearance values
  */
 AStarFinder.prototype.getClearanceGrid = function(grid) {
-  var clearance = new Array(grid.height).map(item => new Array(grid.width));
+  var clearance = new Array(grid.height).fill(0).map(function(item) { return new Array(grid.width) });
   var junk = [];
   for (var y = 0; y < grid.height; y++) {
     for (var x = 0; x < grid.width; x++) {

--- a/src/finders/AStarFinder.js
+++ b/src/finders/AStarFinder.js
@@ -168,5 +168,19 @@ AStarFinder.prototype.annotateNode = function(n, grid) {
     }
 };
 
+/**
+ * Get a grid with clearance values
+ */
+AStarFinder.prototype.getClearanceGrid = function(grid) {
+  var clearance = new Array(grid.height).map(item => new Array(grid.width));
+  var junk = [];
+  for (var y = 0; y < grid.height; y++) {
+    for (var x = 0; x < grid.width; x++) {
+        clearance[y][x] = grid.getNodeAt(x, y).clearance;
+    }
+  }
+  return clearance;
+}
+
 
 module.exports = AStarFinder;


### PR DESCRIPTION
This PR adds an ```unitSize``` option for ```AStarFinder``` to find a path for units/characters/robots that are larger than a node.

It works by computing clearance value for all nodes in the grid and comparing this value with the unitSize.

The clearance grid can be accessed using ```finder.getClearanceGrid(grid)```.
![clearance](https://user-images.githubusercontent.com/8517072/28317289-9dd6f2f0-6bc6-11e7-8d1a-162c7ef23d13.png)
