### PR TITLE
Algorithm's stats now show right after start is clicked

### DIFF
--- a/docs/contributor-guide/authors.md
+++ b/docs/contributor-guide/authors.md
@@ -5,6 +5,7 @@ This is the alphabetically sorted list of contributors to PathFinding.js:
 Anders Riutta <https://github.com/ariutta><br>
 Chris Khoo <https://github.com/chriskck><br>
 Gerjo <https://github.com/Gerjo><br>
+Henry Quillin <https://github.com/HenryQuillin><br>
 Juan Pablo Canepa <https://github.com/jpcanepa><br>
 Mat Gadd <https://github.com/Drarok><br>
 Murilo Pereira <https://github.com/mpereira><br>

--- a/visual/js/controller.js
+++ b/visual/js/controller.js
@@ -178,11 +178,6 @@ $.extend(Controller, {
         // => ready
     },
     onfinish: function(event, from, to) {
-        View.showStats({
-            pathLength: PF.Util.pathLength(this.path),
-            timeSpent:  this.timeSpent,
-            operationCount: this.operationCount,
-        });
         View.drawPath(this.path);
         // => finished
     },

--- a/visual/js/controller.js
+++ b/visual/js/controller.js
@@ -143,6 +143,13 @@ $.extend(Controller, {
         this.timeSpent = (timeEnd - timeStart).toFixed(4);
 
         this.loop();
+        
+        // Shows the algorithm stats when start is clicked 
+        View.showStats({
+            pathLength: PF.Util.pathLength(this.path),
+            timeSpent:  this.timeSpent,
+            operationCount: this.operationCount,
+        });
         // => searching
     },
     onrestart: function() {


### PR DESCRIPTION
This pull request is for issue #195
"I am using this program for a research paper comparing the efficiency of pathfinding algorithms. It would be very helpful if the analytics(length, time, operations) were shown before the visualization is complete. I think others will prefer this as well." 

I added showStats() to the onsearch function and removed showStats from the onfinish function. 
