### PR TITLE
Fix smoothing

### DIFF
--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -164,7 +164,7 @@ function smoothenPath(grid, path) {
             }
         }
         if (blocked) {
-            let lastValidCoord = path[i - 1];
+            var lastValidCoord = path[i - 1];
             newPath.push(lastValidCoord);
             sx = lastValidCoord[0];
             sy = lastValidCoord[1];


### PR DESCRIPTION
When using Util.smoothenPath with an unwalkable node between points in the path, lastValidCoord was never defined, so this was failing.