### PR TITLE
Fix bug causing smoothenPath to fail when the path is blocked

### DIFF
--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -164,7 +164,7 @@ function smoothenPath(grid, path) {
             }
         }
         if (blocked) {
-            lastValidCoord = path[i - 1];
+            var lastValidCoord = path[i - 1];
             newPath.push(lastValidCoord);
             sx = lastValidCoord[0];
             sy = lastValidCoord[1];


### PR DESCRIPTION
smoothenPath currently fails if the path is blocked.


```
Uncaught ReferenceError: assignment to undeclared variable lastValidCoord

smoothenPath - Util.js:167
```


Note: I discovered this issue using AStarFinder.